### PR TITLE
fix: Return the mimeType not the extension

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -61,7 +61,7 @@ class Utils implements IUtils {
     const type = Object.entries(MimeTypes).find(
       (mime) => mime[0] === extension
     );
-    if (type) return type[0];
+    if (type) return type[1];
     return '';
   };
 }


### PR DESCRIPTION
type[0] contains the extension, type[1] contains the mimeType.

Before `file.mimeType` was `.pdf` on iOS instead of `application/pdf` for instance 